### PR TITLE
添加武器抽卡系统，支持加权单抽和十连抽机制，具备完善的数据加载和用户记录持久化功能。

### DIFF
--- a/core/lottery.py
+++ b/core/lottery.py
@@ -2,47 +2,151 @@ import json
 import random
 from pathlib import Path
 
-import aiohttp  # noqa: F401
-import astrbot.api.message_components as Comp
-from aiocqhttp import CQHttp  # noqa: F401
 from astrbot.api import logger
-from astrbot.api.event import AstrMessageEvent, filter
-from astrbot.api.star import Context, Star, register
 
 from ..utils.utils import read_json, write_json
 
 
-class lottery:
- 
+class Lottery:
     def __init__(self):
-        self.weapon_data = None
+        """
+        初始化抽奖系统
+        """
+        BASE_DIR = Path(__file__).resolve().parent.parent
+        self.backpack_path = (
+            BASE_DIR.parent.parent
+            / "plugin_data"
+            / "astrbot_plugin_akasha_terminal"
+            / "user_backpack"
+        )
+        self.weapon_path = BASE_DIR / "data" / "weapon.json"
+        # 字典，定义每个星级下的具体武器 {weapon_star: [weapon_id1,weapon_id2, ...]}
+        weapon_star_data = self.load_weapon_data()
+        # 星级池子含有的武器列表
+        self.weapon_star_data = weapon_star_data if weapon_star_data else {}
+        pool_weights = {"三星武器": 17, "四星武器": 2, "五星武器": 1}
+        self.items = list(pool_weights.keys())
+        self.weights = list(pool_weights.values())
+        self.total_weight = sum(self.weights)
+
+    def load_weapon_data(file_path="weapon.json"):
+        """加载武器数据并按星级分类"""
         try:
-            file_path = Path(__file__).parent.parent / "data" / "weapon.json"
-            with open(file_path, 'r', encoding='utf-8') as f:
-        self.weapon_data = json.load(f)
-        
-        def lottery(self):
-            """执行一次抽奖"""
-            self.items = ["五星", "四星", "三星"]  # 获奖
-            self.weights = ["1", "2", "17"]  # 权重
-            rand_sum = random.uniform(0, 20)  # 生成一个随机数,在0~20之间
+            # 读取JSON文件
+            with open(
+                Path(__file__).parent.parent / file_path, "r", encoding="utf-8"
+            ) as f:
+                weapon_data = json.load(f)
 
-            current = 0
+            # 按ID范围分类武器（300-399:三星, 400-499:四星, 500-599:五星）
+            three_star = []
+            four_star = []
+            five_star = []
 
-            for i in range(0, 3):
-                current += self.weights[i]
-                if rand_sum <= current:
-                    main_prizes = self.items
+            for weapon_key in weapon_data.keys():
+                try:
+                    # 提取武器id
+                    weapon_id = int(weapon_key)
+                    if 300 <= weapon_id <= 399:
+                        three_star.append(weapon_id)
+                    elif 400 <= weapon_id <= 499:
+                        four_star.append(weapon_id)
+                    elif 500 <= weapon_id <= 599:
+                        five_star.append(weapon_id)
+                except ValueError:
+                    # 忽略非数字ID的武器
+                    continue
+            return {
+                "三星武器": three_star,
+                "四星武器": four_star,
+                "五星武器": five_star,
+            }
+        except FileNotFoundError:
+            print(f"错误：未找到{file_path}文件，请确保文件在同目录下")
+            return None
+        except json.JSONDecodeError:
+            print(f"错误：{file_path}文件格式不正确")
+            return None
 
-                    if main_prizes == "五星":
-                        a = random.randint(500, 531)
-                        print(f"{self.weapon_data[a]['name']}")
+    # 根据武器id获取武器详细信息
+    async def get_weapon_info(self, weapon_id: str) -> dict | None:
+        """
+        根据武器ID获取武器详细信息\n
+        :param weapon_id: 武器ID
+        :return: 武器详细信息
+        """
+        weapon_data = await read_json(self.weapon_path)
+        return weapon_data.get(weapon_id)
 
-                    elif main_prizes == "四星":
-                        a = random.randint(400, 429)
-                        print(f"{self.weapon_data[a]['name']}")
+    async def update_data(self, user_id: str, str, target_weapon_id: str) -> bool:
+        """
+        更新用户的抽奖数据，记录抽中的武器\n
+        :param user_id: 用户ID
+        :param star: 武器星级
+        :param weapon: 武器名称
+        :return: 是否更新成功
+        """
+        # 读取现有用户数据
+        self.user_backpack_path = self.backpack_path / f"{user_id}.json"
+        user_backpack = await read_json(self.user_backpack_path) or {}
+        weapon_new_data = await self.get_weapon_info(target_weapon_id)
+        # 初始化抽奖记录结构（如果不存在）
+        if "weapon_data" not in user_backpack:
+            user_backpack["weapon_data"] = {"total_draws": 0, "weapons": {}}
+        if user_backpack["weapon_data"] and isinstance(weapon_new_data, dict):
+            # 更新抽奖记录
+            user_backpack["weapon_data"]["total_draws"] += 1
+            user_backpack["weapon_data"]["weapons"].update(weapon_new_data)
+            # 写回更新后的数据
+            await write_json(self.user_backpack_path, user_backpack)
+            return True
+        else:
+            return False
 
+    async def draw_single(self, user_id: str):
+        """
+        执行单次抽奖\n
+        1. 根据权重选择一个主奖项（星级）
+        2. 从对应的子奖项列表中随机选择一个具体武器
+        3. 返回主奖项和子奖项
+        :return: 抽中的奖项
+        """
+        # 生成一个随机数（0到总权重之间）
+        rand_num = random.uniform(0, self.total_weight)
+        # 确定随机数落在哪个区间
+        current = 0
+        for i, weight in enumerate(self.weights):
+            current += weight
+            if current >= rand_num:
+                # 选中的武器星级
+                weapon_star = self.items[i]
+                if (
+                    weapon_star in self.weapon_star_data
+                    and self.weapon_star_data[weapon_star]
+                ):
+                    # 从该池中随机选择一个具体的武器（等概率）
+                    target_weapon_id = str(
+                        random.choice(self.weapon_star_data[weapon_star])
+                    )
+                    # 更新用户数据
+                    await self.update_data(user_id, target_weapon_id)
+                    weapon_name = (await self.get_weapon_info(target_weapon_id)).get(
+                        "name", "未知武器"
+                    )
+                    if weapon_star and weapon_name:
+                        message = f"恭喜你抽中了{weapon_star}：{weapon_name}！\n"
                     else:
-                        a = random.randint(300, 312)
-                        print(f"{self.weapon_data[a]['name']}")
+                        message = "抽奖失败，请稍后再试~"
+            return message
 
+    async def draw_multiple(self, user_id: str):
+        """
+        执行十连抽\n
+        :param user_id: 用户ID
+        :return: 抽中的奖项列表
+        """
+        message = "十连抽结果如下：\n"
+        for _ in range(10):
+            result = await self.draw_single(user_id)
+            message += result
+        return message

--- a/core/lottery.py
+++ b/core/lottery.py
@@ -23,7 +23,7 @@ class Lottery:
         # 字典，定义每个星级下的具体武器 {weapon_star: [weapon_id1,weapon_id2, ...]}
         weapon_star_data = self.load_weapon_data()
         # 星级池子含有的武器列表
-        self.weapon_star_data = weapon_star_data if weapon_star_data else {}
+        self.weapon_star_data = weapon_star_data or {}
         pool_weights = {"三星武器": 17, "四星武器": 2, "五星武器": 1}
         self.items = list(pool_weights.keys())
         self.weights = list(pool_weights.values())
@@ -78,7 +78,7 @@ class Lottery:
         weapon_data = await read_json(self.weapon_path)
         return weapon_data.get(weapon_id)
 
-    async def update_data(self, user_id: str, str, target_weapon_id: str) -> bool:
+    async def update_data(self, user_id: str, target_weapon_id: str) -> bool:
         """
         更新用户的抽奖数据，记录抽中的武器\n
         :param user_id: 用户ID
@@ -137,7 +137,7 @@ class Lottery:
                         message = f"恭喜你抽中了{weapon_star}：{weapon_name}！\n"
                     else:
                         message = "抽奖失败，请稍后再试~"
-            return message
+                return message
 
     async def draw_multiple(self, user_id: str):
         """

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star, register
 
+from .core.lottery import Lottery
 from .core.shop import Shop
 from .core.task import Task
 from .core.user import User
@@ -30,6 +31,8 @@ class AkashaTerminal(Star):
             self.task_system = Task()
             # 商店系统
             self.shop_system = Shop()
+            # 抽奖系统
+            self.lottery_system = Lottery()
             logger.info("Akasha Terminal插件初始化完成")
         except Exception as e:
             logger.error(f"Akasha Terminal插件初始化失败:{str(e)}")
@@ -152,3 +155,26 @@ class AkashaTerminal(Star):
             from_user_id, input_str
         )
         yield event.plain_result(message)
+
+    @filter.command("抽武器", alias={"单抽武器", "单抽"})
+    async def draw_weapon(self, event: AstrMessageEvent):
+        """单抽一次武器"""
+        try:
+            user_id = str(event.get_sender_id())
+            message = await self.lottery_system.draw_single(user_id)
+            yield event.plain_result(message)
+        except Exception as e:
+            logger.error(f"抽武器失败: {str(e)}")
+            yield event.plain_result("抽武器失败，请稍后再试~")
+            return
+
+    @filter.command("十连抽武器", alias={"十连武器", "十连"})
+    async def draw_ten_weapons(self, event: AstrMessageEvent):
+        """十连抽武器"""
+        try:
+            user_id = str(event.get_sender_id())
+            message = await self.lottery_system.draw_multiple(user_id)
+            yield event.plain_result(message)
+        except Exception as e:
+            logger.error(f"十连抽武器失败: {str(e)}")
+            yield event.plain_result("十连抽武器失败，请稍后再试~")


### PR DESCRIPTION
新功能：
    实现支持单抽和十连抽操作的武器抽奖系统
    添加聊天命令 '抽武器' 和 '十连抽武器' 来触发抽奖
    将每个用户的抽奖历史持久化到 JSON 背包文件中

## Sourcery 摘要

新增一个加权武器扭蛋系统，支持单抽和十连抽命令，并将用户抽奖历史持久化到 JSON 存储。

新功能：
- 引入 Lottery 类，支持加权单抽和十连抽武器
- 添加聊天命令 '抽武器' 和 '十连抽武器'，分别用于触发单抽和十连抽
- 将每个用户的抽奖历史和结果持久化到一个 JSON 背包文件

增强：
- 从 JSON 加载并根据 3★、4★ 和 5★ 星级分类武器数据

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new weighted weapon gacha system with single and ten-draw commands and persist user draw history to JSON storage.

New Features:
- Introduce a Lottery class that supports weighted single and ten weapon draws
- Add chat commands '抽武器' and '十连抽武器' to trigger single and ten draws respectively
- Persist each user's draw history and results in a JSON backpack file

Enhancements:
- Load and categorize weapon data from JSON by 3★, 4★, and 5★ star tiers

</details>