### PR TITLE
update：实现每日签到系统，包含奖励、连续签到、地点/房屋/爱情加成和随机幸运奖励、优化时区设置、增添初始化user数据的工具函数

### DIFF
--- a/core/lottery.py
+++ b/core/lottery.py
@@ -1,10 +1,12 @@
 import json
 import random
+from datetime import date, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import astrbot.api.message_components as Comp
 
-from ..utils.utils import read_json, write_json
+from ..utils.utils import create_user_data, read_json, write_json
 
 
 class Lottery:
@@ -151,13 +153,15 @@ class Lottery:
 
         :return: 抽中的奖项
         """
-        user_data = await read_json(self.user_data_path / f"{user_id}.json") or {}
+        if not (self.user_data_path / f"{user_id}.json").exists():
+            await create_user_data(user_id)
+        user_data = await read_json(self.user_data_path / f"{user_id}.json")
         user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
         weapon_data = user_backpack.get("weapon", {})
         entangled_fate = weapon_data.get("纠缠之缘", 0)
 
-        # 检查纠缠之缘是否足够（10颗/次）
-        cost = 10 * count
+        # 检查纠缠之缘是否足够（1颗/次）
+        cost = 1 * count
         if entangled_fate < cost:
             return [
                 Comp.At(qq=user_id),
@@ -316,3 +320,118 @@ class Lottery:
         #     lines.append(f" ({time_desc})")
         # 更新用户数据
         return message
+
+    async def daily_sign_in(self, user_id: str):
+        """处理每日签到，获取纠缠之缘"""
+        # 设置「中国标准时间」
+        CN_TIMEZONE = ZoneInfo("Asia/Shanghai")
+        if not (self.user_data_path / f"{user_id}.json").exists():
+            await create_user_data(user_id)
+        user_data = await read_json(self.user_data_path / f"{user_id}.json")
+        user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
+        today = date.today(CN_TIMEZONE).strftime("%Y-%m-%d")
+        message = [Comp.At(qq=user_id), Comp.Plain("\n")]
+        # 初始化签到数据及检测是否为首次签到的新用户
+        if "sign_info" not in user_backpack:
+            user_backpack["sign_info"] = {"last_sign": "", "streak_days": 0}
+            judge_new_user = True
+        # 检查是否已签到
+        if user_backpack["sign_info"]["last_sign"] == today:
+            message.append(Comp.Plain("你今天已经签到过啦，明天再来吧~"))
+            return message
+        base_reward = 1
+        location_bonus, house_bonus, love_bonus, streak_bonus = 0, 0, 0, 0
+        # 新用户奖励
+        if judge_new_user:
+            message.append(
+                Comp.Plain(
+                    "🎉 欢迎来到虚空武器抽卡系统！\n💎 注册成功，获得初始纠缠之缘5颗\n\n"
+                )
+            )
+            base_reward += 5
+        # 更新签到信息
+        last_sign = user_backpack["sign_info"]["last_sign"]
+        if last_sign == (date.today(CN_TIMEZONE) - timedelta(days=1)).strftime(
+            "%Y-%m-%d"
+        ):
+            if user_backpack["sign_info"]["streak_days"] <= 30:
+                user_backpack["sign_info"]["streak_days"] += 1
+            else:
+                user_backpack["sign_info"]["streak_days"] = 1  # 连续签到天数上限30天
+        else:
+            user_backpack["sign_info"]["streak_days"] = 1
+        streak_count = user_backpack["sign_info"]["streak_days"]
+        user_backpack["sign_info"]["last_sign"] = today
+        # 连续签到加成（每3天+1，最多+5）
+        streak_bonus = min(streak_count // 3, 5)
+
+        # 位置加成计算
+        if user_data["home"] and "place" in user_data["home"]:
+            current_place = user_data.get("home", {}).get("place", "home")
+            location_config = {
+                "city": (2, "城市的繁华带来额外收益"),
+                "business": (3, "商业区的商机"),
+                "bank": (1, "银行的稳定收益"),
+                "prison": (-1, "监狱环境恶劣"),
+                "home": (0, "家的温馨"),
+            }
+            if current_place in location_config:
+                location_bonus, location_desc = location_config[current_place]
+            else:
+                location_bonus, location_desc = 0, "未知地点"
+
+        # 房屋等级加成
+        if user_data["house"] and "house_level" in user_data["house"]:
+            house_level = user_data.get("house", {}).get("house_level", 1)
+            house_bonus = house_level // 2  # 每2级+1颗纠缠之缘
+
+        # 好感度加成
+        if user_data["home"] and "spouse_id" in user_data["home"]:
+            spouse_name = user_data["home"].get("spouse_name", "伴侣")
+            spouse_id = user_data["home"].get("spouse_id")
+            if spouse_id and spouse_id not in [0, None, "", "0"]:
+                love_level = user_data["home"].get("love", 0)
+                love_bonus = love_level // 50  # 每50好感度+1
+
+        total_reward = (
+            base_reward + location_bonus + house_bonus + love_bonus + streak_bonus
+        )
+
+        message.extend(
+            [
+                Comp.Plain(f"✅ 签到成功！获得{total_reward - 5}颗纠缠之缘\n"),
+                Comp.Plain(
+                    f"💎 当前拥有：{user_backpack['weapon']['纠缠之缘']}颗纠缠之缘\n"
+                ),
+                Comp.Plain(f"📅 当前连续签到{streak_count}天\n"),
+                Comp.Plain("💡 可以使用[抽武器]来获得强力装备！\n"),
+            ]
+        )
+
+        # 幸运奖励事件（10%概率）
+        if random.random() < 0.1:
+            lucky_reward = 5 + random.randint(0, 10)
+            message.append(
+                Comp.Plain(f"🎁 幸运奖励：额外获得{lucky_reward}颗纠缠之缘！\n\n")
+            )
+        # 添加各种加成信息
+        if location_bonus != 0:
+            message.append(f"📍 位置加成：{location_bonus:+d} ({location_desc})")
+        if house_bonus > 0:
+            message.append(f"🏠 房屋加成：+{house_bonus}")
+        if love_bonus > 0:
+            message.append(f"💕 {spouse_name}的爱意加成：+{love_bonus}")
+        if streak_bonus > 0:
+            message.append(f"🔥 连续签到{streak_count}天加成：+{streak_bonus}")
+        # 更新用户金钱
+        user_backpack["weapon"]["纠缠之缘"] += total_reward + lucky_reward
+        await write_json(self.backpack_path / f"{user_id}.json", user_backpack)
+        return message
+
+    async def _get_streak_info(self, user_id: str, group_id: str) -> tuple[int, int]:
+        """获取连续签到信息（连续天数，加成值）"""
+        user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
+        sign_info = user_backpack.get("sign_info", {})
+        group_signs = sign_info.get("group_signs", {})
+        group_data = group_signs.get(group_id, {"last_sign": "", "streak_days": 0})
+        return group_data["streak_days"], group_data["last_sign"]

--- a/core/lottery.py
+++ b/core/lottery.py
@@ -1,6 +1,6 @@
 import json
 import random
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -329,7 +329,7 @@ class Lottery:
             await create_user_data(user_id)
         user_data = await read_json(self.user_data_path / f"{user_id}.json")
         user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
-        today = date.today(CN_TIMEZONE).strftime("%Y-%m-%d")
+        today = datetime.now(CN_TIMEZONE).date().strftime("%Y-%m-%d")
         message = [Comp.At(qq=user_id), Comp.Plain("\n")]
         # 初始化签到数据及检测是否为首次签到的新用户
         if "sign_info" not in user_backpack:
@@ -409,6 +409,7 @@ class Lottery:
         )
 
         # 幸运奖励事件（10%概率）
+        lucky_reward = 0
         if random.random() < 0.1:
             lucky_reward = 5 + random.randint(0, 10)
             message.append(
@@ -427,11 +428,3 @@ class Lottery:
         user_backpack["weapon"]["纠缠之缘"] += total_reward + lucky_reward
         await write_json(self.backpack_path / f"{user_id}.json", user_backpack)
         return message
-
-    async def _get_streak_info(self, user_id: str, group_id: str) -> tuple[int, int]:
-        """获取连续签到信息（连续天数，加成值）"""
-        user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
-        sign_info = user_backpack.get("sign_info", {})
-        group_signs = sign_info.get("group_signs", {})
-        group_data = group_signs.get(group_id, {"last_sign": "", "streak_days": 0})
-        return group_data["streak_days"], group_data["last_sign"]

--- a/core/shop.py
+++ b/core/shop.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
+from zoneinfo import ZoneInfo
 
 from ..utils.utils import read_json, write_json
 
@@ -24,6 +25,8 @@ class Shop:
 
     def _init_default_data(self) -> None:
         """初始化默认商店数据和用户背包（仅当文件不存在时）"""
+        # 设置「中国标准时间」
+        CN_TIMEZONE = ZoneInfo("Asia/Shanghai")
         # 初始化商店数据
         if not self.shop_data_path.exists():
             default_shop = {
@@ -105,7 +108,7 @@ class Shop:
                     "金币袋",
                     "双倍经验卡",
                 ],  # 每日刷新的商品ID
-                "last_refresh": datetime.now().strftime("%Y-%m-%d"),
+                "last_refresh": datetime.now(CN_TIMEZONE).strftime("%Y-%m-%d"),
             }
             asyncio.run(self._save_data(self.shop_data_path, default_shop))
         # 初始化用户背包路径文件

--- a/core/user.py
+++ b/core/user.py
@@ -46,6 +46,8 @@ class User:
                     "spouse_id": "",
                     "spouse_name": "",
                     "wait": 0,
+                    "place": "home",
+                    "placetime": 0,
                     "money": 100,
                     "love": 0,
                 }

--- a/main.py
+++ b/main.py
@@ -178,3 +178,14 @@ class AkashaTerminal(Star):
         except Exception as e:
             logger.error(f"十连抽武器失败: {str(e)}")
             yield event.plain_result("十连抽武器失败，请稍后再试~")
+
+    @filter.command("签到", alias={"每日签到"})
+    async def sign_in(self, event: AstrMessageEvent):
+        """进行每日签到"""
+        try:
+            user_id = str(event.get_sender_id())
+            message = await self.lottery_system.daily_sign_in(user_id)
+            yield event.plain_result(message)
+        except Exception as e:
+            logger.error(f"每日签到失败: {str(e)}")
+            yield event.plain_result("每日签到失败，请稍后再试~")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,6 +3,7 @@ import fcntl
 import json
 import os
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict
 
@@ -65,6 +66,64 @@ def logo_AATP():
         print("".join(f"{c}{cell:<10}{reset}" for c, cell in zip(colors, row)))
 
     print("\n\033[95m欢迎使用虚空插件！\033[0m")
+
+
+# 初始化用户数据的工具函数
+async def create_user_data(user_id: str) -> bool:
+    """创建user系统初始数据"""
+    # 创建默认用户数据
+    user_data_path = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "plugin_data"
+        / "astrbot_plugin_akasha_terminal"
+        / "user_data"
+    )
+    default_user_data = {
+        "user": {
+            "default": {
+                "id": user_id,
+                "nickname": "",
+                "level": 1,
+                "experience": 0,
+                "created_at": time.time(),
+            }
+        },
+        "battle": {
+            "default": {
+                "experience": 0,
+                "level": 0,
+                "levelname": "无等级",
+                "privilege": 0,
+            }
+        },
+        "home": {
+            "default": {
+                "spouse_id": "",
+                "spouse_name": "",
+                "wait": 0,
+                "place": "home",
+                "placetime": 0,
+                "money": 100,
+                "love": 0,
+            }
+        },
+        "quest": {
+            "default": {
+                "daily": {},
+                "weekly": {},
+                "special": {},
+                "quest_points": 0,
+                "last_daily_reset": "",
+                "last_weekly_reset": "",
+            }
+        },
+    }
+
+    # 确保目录存在
+    user_data_path.mkdir(parents=True, exist_ok=True)
+    # 写入用户数据
+    await write_json(user_data_path / f"{user_id}.json", default_user_data)
+    return True
 
 
 async def read_json(file_path: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Sourcery 总结

引入每日签到功能，包含全面的奖励计算；确保用户数据在首次使用时自动生成；优化日期敏感任务的时区处理；并调整武器抽取成本。

新功能：
- 在 Lottery 中实现每日签到系统，包含奖励、连续签到、地点/房屋/爱情加成和随机幸运奖励
- 添加 create_user_data 工具函数，用于初始化新的用户配置文件数据
- 在 main 中暴露 sign_in 命令以执行每日签到

改进：
- 如果在抽取和签到时用户数据文件不存在，则自动初始化
- 将武器抽取成本从每次抽取的 10 个纠缠之缘减少到 1 个
- 在签到和商店刷新中，对基于日期的操作应用 Asia/Shanghai 时区
- 使用 place 和 placetime 字段丰富默认用户数据

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a daily sign-in feature with comprehensive reward calculation, ensure user data is auto-generated on first use, refine time zone handling for date-sensitive tasks, and adjust weapon draw cost.

New Features:
- Implement daily sign-in system in Lottery with rewards, streak, location/house/love bonuses and random lucky rewards
- Add create_user_data utility for initializing new user profile data
- Expose sign_in command in main to perform daily sign-in

Enhancements:
- Automatically initialize user data file on draws and sign-ins if not present
- Reduce weapon draw cost from 10 to 1 entangled fate per draw
- Apply Asia/Shanghai timezone for date-based operations in sign-in and shop refresh
- Enrich default user data with place and placetime fields

</details>