### PR TITLE
update：新增”开挂“指令，用于管理员为用户增加纠缠之缘数量

### DIFF
--- a/core/lottery.py
+++ b/core/lottery.py
@@ -117,9 +117,9 @@ class Lottery:
                     "未出五星计数": 0,
                     "未出四星计数": 0,
                 }
-        if user_data == "user_data":
+        if only_data_or_backpack == "user_data":
             return user_data
-        elif user_backpack == "user_backpack":
+        elif only_data_or_backpack == "user_backpack":
             return user_backpack
         return user_data, user_backpack
 

--- a/core/lottery.py
+++ b/core/lottery.py
@@ -9,7 +9,7 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
 
-from ..utils.utils import create_user_data, read_json, write_json
+from ..utils.utils import create_user_data, get_at_ids, read_json, write_json
 
 
 class Lottery:
@@ -87,28 +87,40 @@ class Lottery:
         weapon_data = await read_json(self.weapon_path)
         return weapon_data.get(weapon_id)
 
-    async def get_user_data_and_backpack(self, user_id: str):
+    async def get_user_data_and_backpack(
+        self, user_id: str, only_data_or_backpack: str | None = None
+    ) -> dict | tuple[dict, dict]:
         """获取用户数据和背包数据（不存在则创建）"""
-        user_data_file = self.user_data_path / f"{user_id}.json"
-        if not user_data_file.exists():
-            await create_user_data(user_id)
-        user_data = await read_json(user_data_file)
-        user_backpack = await read_json(self.backpack_path / f"{user_id}.json") or {}
+        user_data = None
+        user_backpack = None
+        if only_data_or_backpack in (None, "user_data"):
+            user_data_file = self.user_data_path / f"{user_id}.json"
+            if not user_data_file.exists():
+                await create_user_data(user_id)
+            user_data = await read_json(user_data_file)
 
-        # 初始化武器背包结构
-        if "weapon" not in user_backpack:
-            user_backpack["weapon"] = {
-                "纠缠之缘": 0,
-                "总抽卡次数": 0,
-                "武器计数": {},
-                "武器详细": {
-                    "三星武器": {"数量": 0, "详细信息": []},
-                    "四星武器": {"数量": 0, "详细信息": []},
-                    "五星武器": {"数量": 0, "详细信息": []},
-                },
-                "未出五星计数": 0,
-                "未出四星计数": 0,
-            }
+        if only_data_or_backpack in (None, "user_backpack"):
+            user_backpack = (
+                await read_json(self.backpack_path / f"{user_id}.json") or {}
+            )
+            # 初始化武器背包结构
+            if "weapon" not in user_backpack:
+                user_backpack["weapon"] = {
+                    "纠缠之缘": 0,
+                    "总抽卡次数": 0,
+                    "武器计数": {},
+                    "武器详细": {
+                        "三星武器": {"数量": 0, "详细信息": []},
+                        "四星武器": {"数量": 0, "详细信息": []},
+                        "五星武器": {"数量": 0, "详细信息": []},
+                    },
+                    "未出五星计数": 0,
+                    "未出四星计数": 0,
+                }
+        if user_data == "user_data":
+            return user_data
+        elif user_backpack == "user_backpack":
+            return user_backpack
         return user_data, user_backpack
 
     async def update_data(
@@ -597,3 +609,55 @@ class Lottery:
         except Exception as e:
             logger.error(f"展示武器库失败: {str(e)}")
             return "获取武器库信息时出错，请稍后再试~"
+
+    async def handle_cheat_command(self, event: AiocqhttpMessageEvent, input_str: str):
+        """处理开挂命令"""
+        try:
+            to_user_id = None
+            amount = None
+            parts = input_str.strip().split()
+            if not parts:
+                return (
+                    False,
+                    "请指定增加的纠缠之缘数量，使用方法:\n"
+                    "/开挂 数量 \n"
+                    "或：/开挂 @用户/qq号 数量",
+                )
+            to_user_ids = get_at_ids(event)
+            if isinstance(to_user_ids, list) and to_user_ids:
+                to_user_id = to_user_ids[0]
+            try:
+                if to_user_id:
+                    if len(parts) >= 2:
+                        amount = int(parts[1])
+                    else:
+                        return (
+                            False,
+                            "请指定增加的纠缠之缘数量，使用方法:\n"
+                            "/开挂 @用户/qq号 数量",
+                        )
+                else:
+                    if len(parts) >= 2 and parts[0].isdigit():
+                        to_user_id = parts[0]
+                        amount = int(parts[1])
+                    else:
+                        amount = int(parts[0])
+            except ValueError:
+                return (False, "金额必须是整数，请重新输入")
+            if not to_user_id:
+                to_user_id = str(event.get_sender_id())
+            if amount <= 0:
+                return False, "增加的金额必须为正整数"
+            user_backpack = await self.get_user_data_and_backpack(
+                to_user_id, only_data_or_backpack="user_backpack"
+            )
+            user_backpack["weapon"]["纠缠之缘"] += amount
+            await write_json(self.backpack_path / f"{to_user_id}.json", user_backpack)
+            return (
+                True,
+                f"成功为用户{to_user_id}增加 {amount} 颗纠缠之缘\n"
+                f"当前纠缠之缘: {user_backpack['weapon']['纠缠之缘']}颗",
+            )
+        except Exception as e:
+            logger.error(f"处理开挂命令失败: {str(e)}")
+            return False, "处理开挂命令时发生错误，请稍后再试~"

--- a/core/user.py
+++ b/core/user.py
@@ -273,7 +273,11 @@ class User:
             home_data = await self.get_home_data(to_user_id)
             home_data["money"] = home_data.get("money", 0) + amount
             await self.update_home_data(to_user_id, home_data)
-            return True, f"成功增加 {amount} 金钱\n当前金钱: {home_data['money']}"
+            return (
+                True,
+                f"成功为用户{to_user_id}增加 {amount} 金钱\n"
+                f"当前金钱: {home_data['money']}",
+            )
         except Exception as e:
             logger.error(f"增加用户金钱失败: {str(e)}")
             return False, "增加用户金钱失败，请稍后再试~"

--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ class AkashaTerminal(Star):
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("开挂", alias={"增加纠缠之缘", "添加纠缠之缘"})
     async def cheat(self, event: AiocqhttpMessageEvent):
-        """增添纠缠之缘，使用方法: /增加金钱 金额"""
+        """增添纠缠之缘，使用方法: /开挂 数量"""
         cmd_prefix = event.message_str.split()[0]
         input_str = event.message_str.replace(cmd_prefix, "", 1).strip()
         success, message = await self.lottery_system.handle_cheat_command(

--- a/main.py
+++ b/main.py
@@ -173,3 +173,14 @@ class AkashaTerminal(Star):
         """展示背包武器的统计信息"""
         message = await self.lottery_system.show_my_weapons(event)
         yield event.plain_result(message)
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("开挂", alias={"增加纠缠之缘", "添加纠缠之缘"})
+    async def cheat(self, event: AiocqhttpMessageEvent):
+        """增添纠缠之缘，使用方法: /增加金钱 金额"""
+        cmd_prefix = event.message_str.split()[0]
+        input_str = event.message_str.replace(cmd_prefix, "", 1).strip()
+        success, message = await self.lottery_system.handle_cheat_command(
+            event, input_str
+        )
+        yield event.plain_result(message)


### PR DESCRIPTION
## Sourcery 总结

添加一个仅限管理员使用的作弊命令，用于授予用户“纠缠之缘”，重构用户数据/背包获取逻辑以支持选择性加载，并更新金钱添加函数中的消息提示

新功能：
- 引入 `handle_cheat_command` 和一个仅限管理员使用的 `/开挂` 命令及其别名，用于向用户授予纠缠之缘

改进：
- 重构 `get_user_data_and_backpack`，以支持仅获取用户数据、仅获取背包数据或两者都获取

杂项：
- 调整 `add_money` 成功消息，使其包含目标用户 ID 和格式化的换行符

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an admin-only cheat command for granting ‘纠缠之缘’ to users, refactor user data/backpack retrieval for selective loading, and update messaging in the money addition function

New Features:
- Introduce handle_cheat_command and an admin-only `/开挂` command with aliases to grant entanglement tokens to users

Enhancements:
- Refactor get_user_data_and_backpack to allow fetching only user data, only backpack data, or both

Chores:
- Adjust add_money success message to include target user ID and formatted line break

</details>