### PR TITLE
update：加入抽卡冷却时间、新增秒数格式化为X天X小时X分X秒的工具函数

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -155,58 +155,46 @@
             }
         }
     },
-    "other_systems": {
+    "other_system": {
         "description": "其他系统",
         "type": "object",
         "hint": "",
         "items": {
-            "gacha_cooldown": {
+            "draw_card_cooldown": {
                 "description": "抽卡冷却时间",
                 "type": "int",
                 "hint": "抽卡系统的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 3600
+                "default": 10
             },
             "duel_cooldown": {
                 "description": "决斗冷却时间",
                 "type": "int",
                 "hint": "决斗系统的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 3600
+                "default": 5
             },
             "exercise_cooldown": {
                 "description": "修炼冷却时间",
                 "type": "int",
                 "hint": "修炼系统的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 7200
+                "default": 5
             },
             "breakthrough_cooldown": {
                 "description": "突破冷却时间",
                 "type": "int",
                 "hint": "突破系统的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 7200
+                "default": 5
             },
             "idcard_cooldown": {
                 "description": "身份证查询冷却时间",
                 "type": "int",
                 "hint": "身份证查询的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 300
+                "default": 10
             },
             "cpwsc_cooldown": {
                 "description": "猜拳冷却时间",
                 "type": "int",
                 "hint": "猜拳系统的冷却时间（秒）",
-                "default": 0,
-                "min": 0,
-                "max": 300
+                "default": 10
             }
         }
     },

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -280,7 +280,4 @@ def seconds_to_duration(seconds) -> str:
             break
 
     # 处理0秒的情况
-    if not parts:
-        return "0秒"
-
-    return "".join(parts)
+    return "0秒" if not parts else "".join(parts)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -253,3 +253,34 @@ async def get_nickname(event: AiocqhttpMessageEvent, user_id) -> str:
         group_id=int(group_id), user_id=int(user_id)
     )
     return all_info.get("card") or all_info.get("nickname")
+
+
+def seconds_to_duration(seconds) -> str:
+    """将秒数转换为友好的时长字符串，如将秒数转换为"1天2小时3分4秒"""
+    if not isinstance(seconds, (int, float)) or seconds < 0:
+        return "输入必须是非负的数字"
+
+    # 定义时间单位及其对应的秒数
+    units = [
+        ("天", 86400),
+        ("小时", 3600),
+        ("分", 60),
+        ("秒", 1),
+    ]
+    parts = []
+    remaining = int(round(seconds))  # 四舍五入到整数
+
+    for unit_name, unit_seconds in units:
+        if remaining >= unit_seconds:
+            count = remaining // unit_seconds
+            parts.append(f"{count}{unit_name}")
+            remaining %= unit_seconds
+
+        if remaining == 0:
+            break
+
+    # 处理0秒的情况
+    if not parts:
+        return "0秒"
+
+    return "".join(parts)


### PR DESCRIPTION
## Sourcery 摘要

为武器抽取添加组级别冷却时间，冷却时间可配置，并引入一个工具函数，用于将秒数格式化为人类可读的时长字符串。

新功能：
- 在 Lottery.weapon_draw 中实现组特定的冷却时间强制执行
- 添加 seconds_to_duration 工具函数，用于将秒数格式化为 "X天X小时X分X秒"

改进：
- 扩展 AkashaTerminal 以从插件配置中加载 draw_card_cooldown
- 将配置的冷却时间值传递给 weapon_draw，并在每次抽取后更新冷却时间戳

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add group-level cooldown for weapon draws with configurable cooldown duration and introduce a utility to format seconds into a human-readable duration string.

New Features:
- Implement group-specific cooldown enforcement in Lottery.weapon_draw
- Add seconds_to_duration utility function to format seconds into "X天X小时X分X秒"

Enhancements:
- Extend AkashaTerminal to load draw_card_cooldown from plugin config
- Pass configured cooldown value into weapon_draw and update cooldown timestamp after each draw

</details>